### PR TITLE
build: bump gradle 6.9.2 -> 8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,13 +72,13 @@ dependencies {
 task sourceJar(type: Jar) {
     description = "Create a JAR with all sources"
     from sourceSets.main.allSource
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     description = "Create a JAR with the JavaDoc for the java sources"
     from javadoc.destinationDir
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
 }
 
 // Define the artifacts we want to publish (the .pom will also be included since the Maven plugin is active)
@@ -127,8 +127,8 @@ publishing {
             // Without this we get a .pom with no dependencies
             from components.java
 
-            artifact source: sourceJar, classifier: 'sources'
-            artifact source: javadocJar, classifier: 'javadoc'
+            artifact source: sourceJar, archiveClassifier: 'sources'
+            artifact source: javadocJar, archiveClassifier: 'javadoc'
 
             repositories {
                 maven {

--- a/build.gradle
+++ b/build.gradle
@@ -127,8 +127,8 @@ publishing {
             // Without this we get a .pom with no dependencies
             from components.java
 
-            artifact source: sourceJar, archiveClassifier: 'sources'
-            artifact source: javadocJar, archiveClassifier: 'javadoc'
+            artifact source: sourceJar, classifier: 'sources'
+            artifact source: javadocJar, classifier: 'javadoc'
 
             repositories {
                 maven {

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ group = 'org.terasology'
 
 archivesBaseName = 'splash-screen' // for local jar files
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+tasks.compileJava {
+    java.sourceCompatibility JavaVersion.VERSION_1_8
+    java.targetCompatibility JavaVersion.VERSION_1_8
+}
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Relates to https://github.com/MovingBlocks/Terasology/pull/5109
Relates to https://github.com/MovingBlocks/Terasology/pull/4653

### Contains

* Updating gradle from 6.9.2 -> 8.2
* Updating gradle's files which became invalid

### How to test

* run `gradlew build` -> should build and run splash screen

### Remarks

Java 20 is not yet supported, see https://github.com/gradle/gradle/issues/23488.

